### PR TITLE
Fix uniformDiscrete

### DIFF
--- a/src/FsRandom/Statistics.fs
+++ b/src/FsRandom/Statistics.fs
@@ -337,7 +337,7 @@ let uniformDiscrete (min, max) =
       outOfRange "min" "Invalid range."
    else
       let range = float <| int64 max - int64 min + 1L
-      let transform u = min + int (u * range)
+      let transform u = int <| int64 min + int64 (u * range)
       Random.map transform ``[0, 1)``
 
 [<CompiledName("Poisson")>]

--- a/tests/FsRandom.Tests/StatisticsTest.fs
+++ b/tests/FsRandom.Tests/StatisticsTest.fs
@@ -364,3 +364,10 @@ let ``Validates mix (float)`` () =
    ks.test(x, "pmix")""")
    |> getP
    |> should be (greaterThan p)
+
+[<Test>]
+let ``uniformDiscrete on full-range of int generates both positive and negative values`` () =
+   let g = uniformDiscrete (System.Int32.MinValue, System.Int32.MaxValue)
+   let values = Random.get <| List.randomCreate 10 g <| Utility.defaultState
+   List.exists (fun x -> x > 0) values |> should be True
+   List.exists (fun x -> x < 0) values |> should be True


### PR DESCRIPTION
uniformDiscrete returned inalid value due to overflow if the range between min and max is large