### PR TITLE
Add XML documentation and simplify framework targeting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,15 @@ jobs:
             - packages
             - paket-files
       - run:
+          name: Build FsRandom
+          command: dotnet build --no-restore
+            
+      - run:
           name: Test FsRandom
-          command: dotnet test ./tests/FsRandom.Tests/FsRandom.Tests.fsproj
+          command: dotnet test ./tests/FsRandom.Tests/FsRandom.Tests.fsproj --no-build
       - run:
           name: Test FsRandom C# extension
-          command: dotnet test ./tests/FsRandom.Tests.CSharp/FsRandom.Tests.CSharp.csproj
+          command: dotnet test ./tests/FsRandom.Tests.CSharp/FsRandom.Tests.CSharp.csproj --no-build
       - run:
           name: Create deploy package
           command: fsharpi tools/build.fsx --clean-deploy --docs --deploy

--- a/FsRandom.nuspec
+++ b/FsRandom.nuspec
@@ -23,7 +23,8 @@
    </metadata>
    <files>
       <file src="Build/lib/net45/FsRandom.dll" target="lib/net45" />
+      <file src="Build/lib/net45/FsRandom.xml" target="lib/net45" />
       <file src="Build/lib/netstandard1.6/FsRandom.dll" target="lib/netstandard1.6" />
-      <file src="Build/lib/netstandard2.0/FsRandom.dll" target="lib/netstandard2.0" />
+      <file src="Build/lib/netstandard1.6/FsRandom.xml" target="lib/netstandard1.6" />
    </files>
 </package>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,7 @@
 source https://api.nuget.org/v3/index.json
 
+storage: none
+
 nuget FSharp.Core
 nuget FsUnit
 nuget MathNet.Numerics
@@ -13,5 +15,3 @@ group Build
   nuget FAKE
   nuget FSharp.Formatting
   nuget Nuget.CommandLine
-
-  http https://github.com/icsharpcode/SharpZipLib/releases/download/0.86.0.518/ICSharpCode.SharpZipLib.dll

--- a/paket.lock
+++ b/paket.lock
@@ -778,6 +778,3 @@ NUGET
     FSharpVSPowerTools.Core (2.3)
       FSharp.Compiler.Service (>= 2.0.0.3)
     NuGet.CommandLine (4.1)
-HTTP
-  remote: https://github.com
-    ICSharpCode.SharpZipLib.dll (/icsharpcode/SharpZipLib/releases/download/0.86.0.518/ICSharpCode.SharpZipLib.dll)

--- a/paket.lock
+++ b/paket.lock
@@ -1,3 +1,4 @@
+STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (4.3.4)
@@ -62,16 +63,16 @@ NUGET
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.NET.Test.Sdk (15.6.2)
+    Microsoft.NET.Test.Sdk (15.7)
       Microsoft.CodeCoverage (>= 1.0.3) - restriction: || (>= net45) (>= netcoreapp1.0)
-      Microsoft.TestPlatform.TestHost (>= 15.6.2) - restriction: >= netcoreapp1.0
+      Microsoft.TestPlatform.TestHost (>= 15.7) - restriction: >= netcoreapp1.0
       Newtonsoft.Json (>= 9.0.1) - restriction: >= uap10.0
       System.ComponentModel.Primitives (>= 4.1) - restriction: >= uap10.0
       System.ComponentModel.TypeConverter (>= 4.1) - restriction: >= uap10.0
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: >= uap10.0
     Microsoft.NETCore.Platforms (2.0.1) - restriction: || (&& (>= monoandroid) (>= netstandard2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net45) (>= netstandard2.0) (< portable-net451+win81+wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.3) (>= netstandard2.0)) (&& (< net46) (>= net461) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (< netstandard1.0) (>= netstandard2.0)) (&& (< netstandard1.3) (>= netstandard2.0) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard2.0) (< portable-net45+win8+wpa81)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarinios)) (&& (>= netstandard2.0) (>= xamarinmac)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos))
     Microsoft.NETCore.Targets (2.0) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81))
-    Microsoft.TestPlatform.ObjectModel (15.6.2) - restriction: >= netcoreapp1.0
+    Microsoft.TestPlatform.ObjectModel (15.7) - restriction: >= netcoreapp1.0
       NETStandard.Library (>= 1.6) - restriction: && (< net451) (>= netstandard1.5)
       System.ComponentModel.EventBasedAsync (>= 4.0.11) - restriction: && (< net451) (>= netstandard1.5)
       System.ComponentModel.TypeConverter (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.4) (< netstandard1.5)) (&& (< net451) (>= netstandard1.5))
@@ -86,9 +87,9 @@ NUGET
       System.Runtime.Serialization.Primitives (>= 4.1.1) - restriction: && (< net451) (>= netstandard1.5)
       System.Threading.Thread (>= 4.0) - restriction: && (< net451) (>= netstandard1.5)
       System.Xml.XPath.XmlDocument (>= 4.0.1) - restriction: && (< net451) (>= netstandard1.5)
-    Microsoft.TestPlatform.TestHost (15.6.2) - restriction: >= netcoreapp1.0
+    Microsoft.TestPlatform.TestHost (15.7) - restriction: >= netcoreapp1.0
       Microsoft.Extensions.DependencyModel (>= 1.0.3) - restriction: >= netcoreapp1.0
-      Microsoft.TestPlatform.ObjectModel (>= 15.6.2) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
+      Microsoft.TestPlatform.ObjectModel (>= 15.7) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
     Microsoft.Win32.Primitives (4.3) - restriction: >= netcoreapp1.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/FsRandom/FsRandom.fsproj
+++ b/src/FsRandom/FsRandom.fsproj
@@ -33,5 +33,5 @@
     <Compile Include="FsRandomExtensions.fsi" />
     <Compile Include="FsRandomExtensions.fs" />
   </ItemGroup>
-  <Import Project="../../.paket/Paket.Restore.targets" />
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/FsRandom/FsRandom.fsproj
+++ b/src/FsRandom/FsRandom.fsproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/tests/FsRandom.Tests.CSharp/FsRandom.Tests.CSharp.csproj
+++ b/tests/FsRandom.Tests.CSharp/FsRandom.Tests.CSharp.csproj
@@ -6,5 +6,5 @@
   <ItemGroup>
     <ProjectReference Include="../../src/FsRandom/FsRandom.fsproj" />
   </ItemGroup>
-  <Import Project="../../.paket/Paket.Restore.targets" />
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/FsRandom.Tests/FsRandom.Tests.fsproj
+++ b/tests/FsRandom.Tests/FsRandom.Tests.fsproj
@@ -26,5 +26,5 @@
   <ItemGroup>
     <ProjectReference Include="../../src/FsRandom/FsRandom.fsproj" />
   </ItemGroup>
-  <Import Project="../../.paket/Paket.Restore.targets" />
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tools/build.fsx
+++ b/tools/build.fsx
@@ -27,7 +27,7 @@ let libDir = buildDir % "lib"
 let docsDir = buildDir % "docs"
 
 let mainSolution = % "src" % "FsRandom" % "FsRandom.fsproj"
-let targetFrameworks = ["net45"; "netstandard1.6"; "netstandard2.0"]
+let targetFrameworks = ["net45"; "netstandard1.6"]
 let projectName = "FsRandom"
 let zipName = deployDir % "FsRandom.zip"
 

--- a/tools/build.fsx
+++ b/tools/build.fsx
@@ -2,7 +2,6 @@
 #I @"../packages/build/FSharp.Compiler.Service/lib/net40"
 #I @"../packages/build/FSharpVSPowerTools.Core/lib/net45"
 #r @"../packages/build/FAKE/tools/FakeLib.dll"
-#r @"../paket-files/build/github.com/ICSharpCode.SharpZipLib.dll"
 #r "FSharp.Literate.dll"
 #r "FSharp.CodeFormat.dll"
 #r "FSharp.MetadataFormat.dll"


### PR DESCRIPTION
This PR:

* Adds XML documentation to the NuGet package.
* Removes _explicit_ support for .NET Standard 2.0. The library already targets .NET Standard 1.6, so it is not needed.
* Paket dependencies are not downloaded at the `packages/` directory, saving space.
* Building became slightly faster by not building the projects again before testing.